### PR TITLE
Remove unnecessary import in Animation

### DIFF
--- a/Sources/Animation/Features/AnimatableProperties.swift
+++ b/Sources/Animation/Features/AnimatableProperties.swift
@@ -1,4 +1,3 @@
-import Klug
 import SwiftUI
 
 struct HueView: View {


### PR DESCRIPTION
Including `import Klug` in AnimatableProperties prevents Xcode Previews from working properly in the Animation module.